### PR TITLE
fix(ex_json_schema): fix map.take errors

### DIFF
--- a/lib/ex_json_schema/validator/max_properties.ex
+++ b/lib/ex_json_schema/validator/max_properties.ex
@@ -27,10 +27,10 @@ defmodule ExJsonSchema.Validator.MaxProperties do
   end
 
   defp do_validate(max_properties, data) when is_map(data) do
-    if Map.size(data) <= max_properties do
+    if map_size(data) <= max_properties do
       []
     else
-      [{"Expected a maximum of #{max_properties} properties but got #{Map.size(data)}", []}]
+      [{"Expected a maximum of #{max_properties} properties but got #{map_size(data)}", []}]
     end
   end
 

--- a/lib/ex_json_schema/validator/min_properties.ex
+++ b/lib/ex_json_schema/validator/min_properties.ex
@@ -27,10 +27,10 @@ defmodule ExJsonSchema.Validator.MinProperties do
   end
 
   defp do_validate(min_properties, data) when is_map(data) do
-    if Map.size(data) >= min_properties do
+    if map_size(data) >= min_properties do
       []
     else
-      [{"Expected a minimum of #{min_properties} properties but got #{Map.size(data)}", []}]
+      [{"Expected a minimum of #{min_properties} properties but got #{map_size(data)}", []}]
     end
   end
 

--- a/lib/ex_json_schema/validator/properties.ex
+++ b/lib/ex_json_schema/validator/properties.ex
@@ -143,6 +143,7 @@ defmodule ExJsonSchema.Validator.Properties do
       properties
       |> keys_as_set()
       |> MapSet.difference(keys_as_set(validated_properties))
+      |> Enum.to_list()
 
     Map.take(properties, unvalidated)
   end

--- a/lib/ex_json_schema/validator/property_names.ex
+++ b/lib/ex_json_schema/validator/property_names.ex
@@ -27,7 +27,7 @@ defmodule ExJsonSchema.Validator.PropertyNames do
   end
 
   defp do_validate(_, false, data = %{}) do
-    if Map.size(data) == 0 do
+    if map_size(data) == 0 do
       []
     else
       [{"Expected data to not have any keys.", []}]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29907172/65533922-2c516980-dec4-11e9-9402-9bb361112eed.png)
 I get so many error messages related to this forked branch of `ex_json_schema` that I am not seeing the real warnings and am pushing them into dev. I'm not sure if this is how we are supposed to go about it. But in the meantime, can we use this fork with the change?